### PR TITLE
optionally accept an object as the `url`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,13 @@ internals.Request = function (options) {
 
     // options: method, url, payload, headers
 
-    var uri = Url.parse(options.url);
+    var url = options.url;
+
+    if (typeof url === 'object') {
+        url = Url.format(url);
+    }
+
+    var uri = Url.parse(url);
     this.url = uri.path;
 
     this.httpVersion = '1.1';

--- a/test/index.js
+++ b/test/index.js
@@ -76,6 +76,36 @@ describe('inject()', function () {
         });
     });
 
+    it('optionally accepts an object as url', function (done) {
+
+        var output = 'example.com:8080|/hello?test=1234';
+
+        var dispatch = function (req, res) {
+
+            res.writeHead(200, { 'Content-Type': 'text/plain', 'Content-Length': output.length });
+            res.end(req.headers.host + '|' + req.url);
+        };
+
+        var url = {
+            protocol: 'http',
+            hostname: 'example.com',
+            port: '8080',
+            pathname: 'hello',
+            query: {
+                test: '1234'
+            }
+        };
+
+        Shot.inject(dispatch, { url: url }, function (res) {
+
+            expect(res.headers.date).to.exist;
+            expect(res.headers.connection).to.exist;
+            expect(res.headers['transfer-encoding']).to.not.exist;
+            expect(res.payload).to.equal(output);
+            done();
+        });
+    });
+
     it('leaves user-agent unmodified', function (done) {
 
         var dispatch = function (req, res) {


### PR DESCRIPTION
When doing complex querystrings, it would be nicer to be able to specify an object for `url` that gets `Url.format` called upon it.
