### PR TITLE
use rawPayload, convert to UTF8 after the whole buffer is available

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -226,8 +226,6 @@ internals.finish = function (response, req, onEnd) {
         var parts = internals.splitBufferInTwo(rawBuffer, sep);
         var payloadBuffer = parts[1];
 
-        res.rawPayload = payloadBuffer;
-
         if (!res.headers['transfer-encoding']) {
             res.payload = payloadBuffer.toString();
             return;
@@ -252,7 +250,7 @@ internals.finish = function (response, req, onEnd) {
         }
         while (size);
 
-        res.payloadBuffer = new Buffer(payloadBytes);
+        res.rawPayload = new Buffer(payloadBytes);
         var headers = rest.toString().split(CRLF);
         headers.forEach(function (header) {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -244,13 +244,13 @@ internals.finish = function (response, req, onEnd) {
             else {
                 var nextData = next.slice(0, size);
                 payloadBytes = payloadBytes.concat(Array.prototype.slice.call(nextData, 0));
-                res.payload += nextData.toString();
                 rest = next.slice(size + 2);
             }
         }
         while (size);
 
         res.rawPayload = new Buffer(payloadBytes);
+        res.payload = res.rawPayload.toString('utf8');
         var headers = rest.toString().split(CRLF);
         headers.forEach(function (header) {
 

--- a/test/index.js
+++ b/test/index.js
@@ -175,7 +175,7 @@ describe('inject()', function () {
 
             Fs.readFile('./package.json', { encoding: 'utf-8' }, function (err, file) {
 
-                Zlib.unzip(res.payloadBuffer, function (err, unzipped) {
+                Zlib.unzip(res.rawPayload, function (err, unzipped) {
 
                     expect(err).to.not.exist();
                     expect(unzipped.toString('utf-8')).to.deep.equal(file);


### PR DESCRIPTION
I accidentally changed the name of  `rawPayload`, that's should comply with hapi api docs. I also moved the UTF8 conversion to the end, it could, result in an improper UTF8 string conversion. I added the `'utf8'` to be super clear about the conversion. 