### PR TITLE
add timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Injects a fake request into an HTTP server.
   - `headers` - an optional object containing request headers.
   - `remoteAddress` - an optional string specifying the client remote address. Defaults to `'127.0.0.1'`.
   - `payload` - an optional request payload. Can be a string, Buffer or object.
+  - `timeout` -  The number of milliseconds to wait without receiving a response before aborting the request. Defaults to unlimited. A timedout inject will have `statusCode` set to 503 (Service Unavailable).
   - `simulate` - an object containing flags to simulate various conditions:
     - `end` - indicates whether the request will fire an `end` event. Defaults to `undefined`, meaning an `end` event will fire.
     - `split` - indicates whether the request payload will be split into chunks. Defaults to `undefined`, meaning payload will not be chunked.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,10 @@
 // Load modules
 
+var Hoek = require('hoek');
 var Http = require('http');
 var Stream = require('stream');
-var Util = require('util');
 var Url = require('url');
-var Hoek = require('hoek');
+var Util = require('util');
 
 
 // Declare internals
@@ -286,10 +286,28 @@ exports.inject = function (dispatchFunc, options, callback) {
 
     options = (typeof options === 'string' ? { url: options } : options);
     var settings = Hoek.applyToDefaults({ method: 'GET' }, options);
+    var timer;
 
     var req = new internals.Request(settings);
-    var res = new internals.Response(req, callback);
-    dispatchFunc(req, res);
+    var res = new internals.Response(req, function (response) {
+
+        if (timer) {
+            clearTimeout(timer);
+        }
+
+        return callback(response);
+    });
+
+    if (options.timeout) {
+        timer = setTimeout(function () {
+
+            res.statusCode = 503;
+            return callback(res);
+
+        }, options.timeout);
+    }
+
+    return dispatchFunc(req, res);
 };
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -468,6 +468,41 @@ describe('inject()', function () {
         });
 
     });
+
+    it('times out', function (done) {
+
+        var output = 'example.com:8080|/hello';
+        var dispatch = function (req, res) {
+
+            res.writeHead(200, { 'Content-Type': 'text/plain', 'Content-Length': output.length });
+        };
+
+        var body = 'Peace and not war is the father of all things';
+        Shot.inject(dispatch, { method: 'get', url: '/', payload: body, timeout: 10 }, function (res) {
+
+            expect(res.statusCode).to.equal(503);
+            expect(res.payload).to.not.exist();
+            done();
+        });
+    });
+
+    it('clears timer when it doesnt timeout', function (done) {
+
+        var output = 'example.com:8080|/hello';
+        var dispatch = function (req, res) {
+
+            res.writeHead(200, { 'Content-Type': 'text/plain', 'Content-Length': output.length });
+            res.end('Scorpio Wins. Flawless Victory');
+        };
+
+        var body = 'Never fight an inanimate object';
+        Shot.inject(dispatch, { method: 'get', url: '/', payload: body, timeout: 5000 }, function (res) {
+
+            expect(res.statusCode).to.equal(200);
+            expect(res.payload).to.equal('Scorpio Wins. Flawless Victory');
+            done();
+        });
+    });
 });
 
 describe('writeHead()', function () {


### PR DESCRIPTION
server.inject within hapi is used to make internal calls to a single proxied endpoint in a project.

Using server.inject appears to be the best solution (as opposed to server.expose) and a timeout is needed.