### PR TITLE
Remove custom output parsing and buffer payload chunks via write()

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -31,11 +31,7 @@ exports = module.exports = internals.Response = class Response extends Http.Serv
         const headers = ((arguments.length === 2 && typeof arguments[1] === 'object') ? arguments[1] : (arguments.length === 3 ? arguments[2] : {}));
         const result = Http.ServerResponse.prototype.writeHead.apply(this, arguments);
 
-        this._headers = this._headers || {};
-        const keys = Object.keys(headers);
-        for (let i = 0; i < keys.length; ++i) {
-            this._headers[keys[i]] = headers[keys[i]];
-        }
+        this._headers = Object.assign({}, this._headers, headers);
 
         // Add raw headers
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -14,6 +14,8 @@ exports = module.exports = internals.Response = function (req, onEnd) {
 
     Http.ServerResponse.call(this, { method: req.method, httpVersionMajor: 1, httpVersionMinor: 1 });
 
+    this.shot = { trailers: {}, payloadChunks: [] };
+
     this.once('finish', () => {
 
         const res = internals.payload(this);
@@ -53,6 +55,7 @@ internals.Response.prototype.writeHead = function () {
 
 internals.Response.prototype.write = function (data, encoding) {
 
+    this.shot.payloadChunks.push(new Buffer(data, encoding));
     Http.ServerResponse.prototype.write.call(this, data, encoding);
     return true;                                                    // Write always returns false when disconnected
 };
@@ -70,6 +73,14 @@ internals.Response.prototype.destroy = function () {
 };
 
 
+internals.Response.prototype.addTrailers = function (trailers) {
+
+    for (const key in trailers) {
+        this.shot.trailers[key.toLowerCase().trim()] = trailers[key].toString().trim();
+    }
+};
+
+
 internals.payload = function (response) {
 
     // Prepare response object
@@ -84,91 +95,12 @@ internals.payload = function (response) {
         trailers: {}
     };
 
-    // Read payload
+    // Prepare payload and trailers
 
-    const raw = [];
-    let rawLength = 0;
-    for (let i = 0; i < response.output.length; ++i) {
-        const chunk = (response.output[i] instanceof Buffer ? response.output[i] : new Buffer(response.output[i], response.outputEncodings[i]));
-        raw.push(chunk);
-        rawLength = rawLength + chunk.length;
-    }
-
-    const rawBuffer = Buffer.concat(raw, rawLength);
-
-    // Parse payload
-
-    res.payload = '';
-
-    const CRLF = '\r\n';
-    const sep = new Buffer(CRLF + CRLF);
-    const parts = internals.splitBufferInTwo(rawBuffer, sep);
-    const payloadBuffer = parts[1];
-
-    if (!res.headers['transfer-encoding']) {
-        res.rawPayload = payloadBuffer;
-        res.payload = payloadBuffer.toString();
-        return res;
-    }
-
-    const CRLFBuffer = new Buffer(CRLF);
-    let rest = payloadBuffer;
-    let payloadBytes = [];
-    let size;
-    do {
-        const payloadParts = internals.splitBufferInTwo(rest, CRLFBuffer);
-        const next = payloadParts[1];
-        size = parseInt(payloadParts[0].toString(), 16);
-        if (size === 0) {
-            rest = next;
-        }
-        else {
-            const nextData = next.slice(0, size);
-            payloadBytes = payloadBytes.concat(Array.prototype.slice.call(nextData, 0));
-            rest = next.slice(size + 2);
-        }
-    }
-    while (size);
-
-    res.rawPayload = new Buffer(payloadBytes);
-    res.payload = res.rawPayload.toString('utf8');
-
-    // Parse trailers
-
-    const trailerLines = rest.toString().split(CRLF);
-    trailerLines.forEach((line) => {
-
-        const trailerParts = line.split(':');
-        if (trailerParts.length === 2) {
-            res.trailers[trailerParts[0].trim().toLowerCase()] = trailerParts[1].trim();
-        }
-    });
+    const rawBuffer = Buffer.concat(response.shot.payloadChunks);
+    res.rawPayload = rawBuffer;
+    res.payload = rawBuffer.toString();
+    res.trailers = response.shot.trailers;
 
     return res;
-};
-
-
-internals.splitBufferInTwo = function (buffer, seperator) {
-
-    for (let i = 0; i < buffer.length - seperator.length; ++i) {
-        if (internals.bufferEqual(buffer.slice(i, i + seperator.length), seperator)) {
-            const part1 = buffer.slice(0, i);
-            const part2 = buffer.slice(i + seperator.length);
-            return [part1, part2];
-        }
-    }
-
-    return [buffer, new Buffer(0)];
-};
-
-
-internals.bufferEqual = function (a, b) {
-
-    for (let i = 0; i < a.length; ++i) {
-        if (a[i] !== b[i]) {
-            return false;
-        }
-    }
-
-    return true;
 };

--- a/lib/response.js
+++ b/lib/response.js
@@ -4,82 +4,75 @@
 
 const Http = require('http');
 const Stream = require('stream');
-const Util = require('util');
 
 // Declare internals
 
 const internals = {};
 
 
-exports = module.exports = internals.Response = function (req, onEnd) {
+exports = module.exports = internals.Response = class Response extends Http.ServerResponse {
 
-    Http.ServerResponse.call(this, { method: req.method, httpVersionMajor: 1, httpVersionMinor: 1 });
+    constructor(req, onEnd) {
 
-    this._shot = { trailers: {}, payloadChunks: [] };
+        super({ method: req.method, httpVersionMajor: 1, httpVersionMinor: 1 });
+        this._shot = { trailers: {}, payloadChunks: [] };
+        this.assignSocket(internals.nullSocket());
 
-    this.assignSocket(internals.nullSocket());
+        this.once('finish', () => {
 
-    this.once('finish', () => {
-
-        const res = internals.payload(this);
-        res.raw.req = req;
-        process.nextTick(() => onEnd(res));
-    });
-};
-
-Util.inherits(internals.Response, Http.ServerResponse);
-
-
-internals.Response.prototype.writeHead = function () {
-
-    const headers = ((arguments.length === 2 && typeof arguments[1] === 'object') ? arguments[1] : (arguments.length === 3 ? arguments[2] : {}));
-    const result = Http.ServerResponse.prototype.writeHead.apply(this, arguments);
-
-    this._headers = this._headers || {};
-    const keys = Object.keys(headers);
-    for (let i = 0; i < keys.length; ++i) {
-        this._headers[keys[i]] = headers[keys[i]];
+            const res = internals.payload(this);
+            res.raw.req = req;
+            process.nextTick(() => onEnd(res));
+        });
     }
 
-    // Add raw headers
+    writeHead() {
 
-    ['Date', 'Connection', 'Transfer-Encoding'].forEach((name) => {
+        const headers = ((arguments.length === 2 && typeof arguments[1] === 'object') ? arguments[1] : (arguments.length === 3 ? arguments[2] : {}));
+        const result = Http.ServerResponse.prototype.writeHead.apply(this, arguments);
 
-        const regex = new RegExp('\\r\\n' + name + ': ([^\\r]*)\\r\\n');
-        const field = this._header.match(regex);
-        if (field) {
-            this._headers[name.toLowerCase()] = field[1];
+        this._headers = this._headers || {};
+        const keys = Object.keys(headers);
+        for (let i = 0; i < keys.length; ++i) {
+            this._headers[keys[i]] = headers[keys[i]];
         }
-    });
 
-    return result;
-};
+        // Add raw headers
 
+        ['Date', 'Connection', 'Transfer-Encoding'].forEach((name) => {
 
-internals.Response.prototype.write = function (data, encoding) {
+            const regex = new RegExp('\\r\\n' + name + ': ([^\\r]*)\\r\\n');
+            const field = this._header.match(regex);
+            if (field) {
+                this._headers[name.toLowerCase()] = field[1];
+            }
+        });
 
-    Http.ServerResponse.prototype.write.call(this, data, encoding);
-    this._shot.payloadChunks.push(new Buffer(data, encoding));
-    return true;                                                    // Write always returns false when disconnected
-};
+        return result;
+    }
 
+    write(data, encoding) {
 
-internals.Response.prototype.end = function (data, encoding) {
+        super.write(data, encoding);
+        this._shot.payloadChunks.push(new Buffer(data, encoding));
+        return true;                                                    // Write always returns false when disconnected
+    }
 
-    Http.ServerResponse.prototype.end.call(this, data, encoding);
-    this.emit('finish');                                            // Will not be emitted when disconnected
-};
+    end(data, encoding) {
 
+        super.end(data, encoding);
+        this.emit('finish');
+    }
 
-internals.Response.prototype.destroy = function () {
+    destroy() {
 
-};
+    }
 
+    addTrailers(trailers) {
 
-internals.Response.prototype.addTrailers = function (trailers) {
-
-    for (const key in trailers) {
-        this._shot.trailers[key.toLowerCase().trim()] = trailers[key].toString().trim();
+        for (const key in trailers) {
+            this._shot.trailers[key.toLowerCase().trim()] = trailers[key].toString().trim();
+        }
     }
 };
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -11,7 +11,7 @@ const Stream = require('stream');
 const internals = {};
 
 
-exports = module.exports = internals.Response = class Response extends Http.ServerResponse {
+exports = module.exports = class Response extends Http.ServerResponse {
 
     constructor(req, onEnd) {
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -5,6 +5,7 @@
 const Http = require('http');
 const Stream = require('stream');
 
+
 // Declare internals
 
 const internals = {};

--- a/lib/response.js
+++ b/lib/response.js
@@ -30,7 +30,7 @@ exports = module.exports = class Response extends Http.ServerResponse {
     writeHead() {
 
         const headers = ((arguments.length === 2 && typeof arguments[1] === 'object') ? arguments[1] : (arguments.length === 3 ? arguments[2] : {}));
-        const result = Http.ServerResponse.prototype.writeHead.apply(this, arguments);
+        const result = super.writeHead.apply(this, arguments);
 
         this._headers = Object.assign({}, this._headers, headers);
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -3,6 +3,7 @@
 // Load modules
 
 const Http = require('http');
+const Stream = require('stream');
 const Util = require('util');
 
 // Declare internals
@@ -15,6 +16,8 @@ exports = module.exports = internals.Response = function (req, onEnd) {
     Http.ServerResponse.call(this, { method: req.method, httpVersionMajor: 1, httpVersionMinor: 1 });
 
     this._shot = { trailers: {}, payloadChunks: [] };
+
+    this.assignSocket(internals.nullSocket());
 
     this.once('finish', () => {
 
@@ -103,4 +106,17 @@ internals.payload = function (response) {
     res.trailers = response._shot.trailers;
 
     return res;
+};
+
+
+// Throws away all written data to prevent response from buffering payload
+
+internals.nullSocket = function () {
+
+    return new Stream.Writable({
+        write(chunk, encoding, callback) {
+
+            setImmediate(callback);
+        }
+    });
 };

--- a/lib/response.js
+++ b/lib/response.js
@@ -14,7 +14,7 @@ exports = module.exports = internals.Response = function (req, onEnd) {
 
     Http.ServerResponse.call(this, { method: req.method, httpVersionMajor: 1, httpVersionMinor: 1 });
 
-    this.shot = { trailers: {}, payloadChunks: [] };
+    this._shot = { trailers: {}, payloadChunks: [] };
 
     this.once('finish', () => {
 
@@ -55,8 +55,8 @@ internals.Response.prototype.writeHead = function () {
 
 internals.Response.prototype.write = function (data, encoding) {
 
-    this.shot.payloadChunks.push(new Buffer(data, encoding));
     Http.ServerResponse.prototype.write.call(this, data, encoding);
+    this._shot.payloadChunks.push(new Buffer(data, encoding));
     return true;                                                    // Write always returns false when disconnected
 };
 
@@ -76,7 +76,7 @@ internals.Response.prototype.destroy = function () {
 internals.Response.prototype.addTrailers = function (trailers) {
 
     for (const key in trailers) {
-        this.shot.trailers[key.toLowerCase().trim()] = trailers[key].toString().trim();
+        this._shot.trailers[key.toLowerCase().trim()] = trailers[key].toString().trim();
     }
 };
 
@@ -97,10 +97,10 @@ internals.payload = function (response) {
 
     // Prepare payload and trailers
 
-    const rawBuffer = Buffer.concat(response.shot.payloadChunks);
+    const rawBuffer = Buffer.concat(response._shot.payloadChunks);
     res.rawPayload = rawBuffer;
     res.payload = rawBuffer.toString();
-    res.trailers = response.shot.trailers;
+    res.trailers = response._shot.trailers;
 
     return res;
 };

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2,7 +2,9 @@
 
 const Joi = require('joi');
 
+
 const internals = {};
+
 
 internals.url = Joi.alternatives(Joi.string().required(), Joi.object().keys({
     protocol: Joi.string(),
@@ -11,6 +13,7 @@ internals.url = Joi.alternatives(Joi.string().required(), Joi.object().keys({
     pathname: Joi.string().required(),
     query: Joi.any()
 }).required());
+
 
 internals.options = Joi.object().keys({
     url: internals.url.required(),
@@ -26,6 +29,7 @@ internals.options = Joi.object().keys({
     remoteAddress: Joi.string(),
     method: Joi.string().regex(/^[a-zA-Z0-9!#\$%&'\*\+\-\.^_`\|~]+$/)
 }).min(1);
+
 
 module.exports = Joi.object().keys({
     dispatchFunc: Joi.func().required(),


### PR DESCRIPTION
For review:

This is an attempt to cleanup the way shot dips into the Node HTTP internals and to avoid the custom HTTP parsing we have in place. 

I've tested with current hapi master on node 4.x.x and node 6.x.x and all tests pass.

It should make https://github.com/hapijs/shot/issues/78 easier to implement too.