### PR TITLE
Utf8 stream payloads

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -98,7 +98,7 @@ internals.Request.prototype.prepare = function (next) {
 
     const chunks = [];
 
-    this._shot.payload.on('data', (chunk) => chunks.push(chunk));
+    this._shot.payload.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
 
     this._shot.payload.on('end', () => {
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -98,7 +98,7 @@ internals.Request.prototype.prepare = function (next) {
 
     const chunks = [];
 
-    this._shot.payload.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+    this._shot.payload.on('data', (chunk) => chunks.push(new Buffer(chunk)));
 
     this._shot.payload.on('end', () => {
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -98,7 +98,7 @@ internals.Request.prototype.prepare = function (next) {
 
     const chunks = [];
 
-    this._shot.payload.on('data', (chunk) => chunks.push(new Buffer(chunk)));
+    this._shot.payload.on('data', (chunk) => chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk));
 
     this._shot.payload.on('end', () => {
 

--- a/test/index.js
+++ b/test/index.js
@@ -554,7 +554,7 @@ describe('inject()', () => {
         });
     });
 
-    it('can handle a stream payload of utf8 strings', (done) => {
+    it('can handle a stream payload of utf-8 strings', (done) => {
 
         const dispatch = function (req, res) {
 

--- a/test/index.js
+++ b/test/index.js
@@ -552,7 +552,24 @@ describe('inject()', () => {
             expect(res.payload).to.equal('hi');
             done();
         });
+    });
 
+    it('can handle a stream payload of utf8 strings', (done) => {
+
+        const dispatch = function (req, res) {
+
+            internals.readStream(req, (buff) => {
+
+                res.writeHead(200, { 'Content-Type': 'text/plain' });
+                res.end(buff);
+            });
+        };
+
+        Shot.inject(dispatch, { method: 'post', url: '/', payload: internals.getTestStream('utf8') }, (res) => {
+
+            expect(res.payload).to.equal('hi');
+            done();
+        });
     });
 
     it('can override stream payload content-length header', (done) => {
@@ -816,7 +833,7 @@ describe('_read()', () => {
 });
 
 
-internals.getTestStream = function () {
+internals.getTestStream = function (encoding) {
 
     const Read = function () {
 
@@ -833,7 +850,13 @@ internals.getTestStream = function () {
         this.push(word[i] ? word[i++] : null);
     };
 
-    return new Read();
+    const stream = new Read();
+
+    if (encoding) {
+        stream.setEncoding(encoding);
+    }
+
+    return stream;
 };
 
 


### PR DESCRIPTION
Sometimes it's useful to be able to give shot a stream payload that is in utf8 encoding mode, such as that coming from the https://github.com/form-data/form-data package. Currently shot will fail with that. This PR fixes it.

Converting string to Buffer was more complicated than it should be (maybe it was just me though). `new Buffer(string)` has been deprecated and `Buffer.from(string)` is only supported since 4.5.0 on the 4 release line. I went with `Buffer.from()`, this isn't technically a breaking change for people on < 4.5.x because the only thing that won't work is the new feature I'm adding here. Nevertheless, someone let me know if there's a better way I missed.
