### PR TITLE
Handle streams of utf8 encoded strings

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -98,7 +98,7 @@ internals.Request.prototype.prepare = function (next) {
 
     const chunks = [];
 
-    this._shot.payload.on('data', (chunk) => chunks.push(chunk));
+    this._shot.payload.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
 
     this._shot.payload.on('end', () => {
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test"
   ],
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=4.5.0"
   },
   "dependencies": {
     "hoek": "4.x.x",

--- a/test/index.js
+++ b/test/index.js
@@ -552,7 +552,24 @@ describe('inject()', () => {
             expect(res.payload).to.equal('hi');
             done();
         });
+    });
 
+    it('can handle a stream payload of utf-8 strings', (done) => {
+
+        const dispatch = function (req, res) {
+
+            internals.readStream(req, (buff) => {
+
+                res.writeHead(200, { 'Content-Type': 'text/plain' });
+                res.end(buff);
+            });
+        };
+
+        Shot.inject(dispatch, { method: 'post', url: '/', payload: internals.getTestStream('utf8') }, (res) => {
+
+            expect(res.payload).to.equal('hi');
+            done();
+        });
     });
 
     it('can override stream payload content-length header', (done) => {
@@ -816,7 +833,7 @@ describe('_read()', () => {
 });
 
 
-internals.getTestStream = function () {
+internals.getTestStream = function (encoding) {
 
     const Read = function () {
 
@@ -833,7 +850,13 @@ internals.getTestStream = function () {
         this.push(word[i] ? word[i++] : null);
     };
 
-    return new Read();
+    const stream = new Read();
+
+    if (encoding) {
+        stream.setEncoding(encoding);
+    }
+
+    return stream;
 };
 
 


### PR DESCRIPTION
This allows you to pass shot a stream that's in utf8 encoding mode, that is a stream of strings - such as the https://github.com/form-data/form-data library provides.

This breaks compatibility with Node < 4.5.0 because of the use of `Buffer.from(string)`.