### PR TITLE
Fix node 8 issues

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -16,7 +16,8 @@ exports = module.exports = class Response extends Http.ServerResponse {
     constructor(req, onEnd) {
 
         super({ method: req.method, httpVersionMajor: 1, httpVersionMinor: 1 });
-        this._shot = { trailers: {}, payloadChunks: [] };
+        this._shot = { headers: null, trailers: {}, payloadChunks: [] };
+        this._headers = {};      // This forces node@8 to always render the headers
         this.assignSocket(internals.nullSocket());
 
         this.once('finish', () => {
@@ -29,10 +30,9 @@ exports = module.exports = class Response extends Http.ServerResponse {
 
     writeHead() {
 
-        const headers = ((arguments.length === 2 && typeof arguments[1] === 'object') ? arguments[1] : (arguments.length === 3 ? arguments[2] : {}));
         const result = super.writeHead.apply(this, arguments);
 
-        this._headers = Object.assign({}, this._headers, headers);
+        this._shot.headers = Object.assign({}, this._headers);       // Should be .getHeaders() since node v7.7
 
         // Add raw headers
 
@@ -41,7 +41,7 @@ exports = module.exports = class Response extends Http.ServerResponse {
             const regex = new RegExp('\\r\\n' + name + ': ([^\\r]*)\\r\\n');
             const field = this._header.match(regex);
             if (field) {
-                this._headers[name.toLowerCase()] = field[1];
+                this._shot.headers[name.toLowerCase()] = field[1];
             }
         });
 
@@ -82,7 +82,7 @@ internals.payload = function (response) {
         raw: {
             res: response
         },
-        headers: response._headers,
+        headers: response._shot.headers,
         statusCode: response.statusCode,
         statusMessage: response.statusMessage,
         trailers: {}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "code": "4.x.x",
-    "lab": "11.x.x"
+    "lab": "13.x.x"
   },
   "scripts": {
     "test": "lab -a code -t 100 -L",

--- a/test/index.js
+++ b/test/index.js
@@ -447,7 +447,7 @@ describe('inject()', () => {
 
         const dispatch = function (req, res) {
 
-            res.writeHead(200, { 'content-type': req.headers['content-type'] });
+            res.writeHead(200);
             req.pipe(res);
         };
 

--- a/test/index.js
+++ b/test/index.js
@@ -32,6 +32,7 @@ describe('inject()', () => {
         const dispatch = function (req, res) {
 
             res.statusMessage = 'Super';
+            res.setHeader('x-extra', 'hello');
             res.writeHead(200, { 'Content-Type': 'text/plain', 'Content-Length': output.length });
             res.end(req.headers.host + '|' + req.url);
         };
@@ -41,8 +42,13 @@ describe('inject()', () => {
             expect(res.statusCode).to.equal(200);
             expect(res.statusMessage).to.equal('Super');
             expect(res.headers.date).to.exist();
-            expect(res.headers.connection).to.exist();
-            expect(res.headers['transfer-encoding']).to.not.exist();
+            expect(res.headers).to.equal({
+                date: res.headers.date,
+                connection: 'keep-alive',
+                'x-extra': 'hello',
+                'content-type': 'text/plain',
+                'content-length': output.length
+            });
             expect(res.payload).to.equal(output);
             expect(res.rawPayload.toString()).to.equal('example.com:8080|/hello');
             done();


### PR DESCRIPTION
I decided to test node 8-rc1 against hapi, which cause some of the tests to fail.

I traced the failures back to `shot`, which also fails it's test-suite, and found backwards compatible fixes to the issues.

The fixing also uncovered an issue where a `setHeader()` call, before the `writeHead()` call with extra headers, causes non-lowercase header names to be included in the resulting `headers` property (on node 7.10). Fortunately, this fix also handles this issue, along with a revised test that detects the issue.