### PR TITLE
Fix for node 8

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -48,16 +48,20 @@ exports = module.exports = class Response extends Http.ServerResponse {
         return result;
     }
 
-    write(data, encoding) {
+    write(data, encoding, callback) {
 
-        super.write(data, encoding);
+        super.write(data, encoding, callback);
         this._shot.payloadChunks.push(new Buffer(data, encoding));
         return true;                                                    // Write always returns false when disconnected
     }
 
-    end(data, encoding) {
+    end(data, encoding, callback) {
 
-        super.end(data, encoding);
+        if (data) {
+            this.write(data, encoding);
+        }
+
+        super.end(callback);
         this.emit('finish');
     }
 


### PR DESCRIPTION
From node docs:

> If data is specified, it is equivalent to calling `response.write(data, encoding)` followed by `request.end(callback)`.

This fix should be backwards compatible.