### PR TITLE
do not check coverage in npm test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ node_js:
   - "node"
 
 sudo: false
+
+script:
+  - npm run test-cov

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "lab": "15.x.x"
   },
   "scripts": {
-    "test": "lab -a code -t 100 -L",
+    "test": "lab -a code -L",
+    "test-cov": "lab -a code -t 100 -L",
     "test-cov-html": "lab -a code -r html -o coverage.html -L"
   },
   "license": "BSD-3-Clause"


### PR DESCRIPTION
This PR introduces a new script `npm run test-cov` to run the lab test with code coverage.
The reason to do so is because code coverage is < 100% in node master (what will be 10.0.0) and it is causing `shot` to fail in CITGM.

```
> shot@4.0.4 test /data/iojs/build/workspace/citgm-smoker/nodes/rhel72-s390x/citgm_tmp/f4cf1474-1f4c-4d4c-8597-19f54ab3ce5a/shot
 > lab -a code -t 100 -L
   
   ............................................
 44 tests complete
 Test duration: 74 ms
 Assertions count: 72 (verbosity: 1.64)
 The following leaks were detected:URL, URLSearchParams
 Coverage: 99.13% (2/230)
 lib/request.js missing coverage on line(s): 124, 125
 Code coverage below threshold: 99.13 < 100
 Linting results: No issues
 npm ERR! Test failed.  See above for more details.
 ``` 