### PR TITLE
Add socket property to request

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -60,6 +60,8 @@ exports = module.exports = internals.Request = function (options) {
         remoteAddress: options.remoteAddress || '127.0.0.1'
     };
 
+    this.socket = this.connection;
+
     let payload = options.payload || null;
     if (payload &&
         typeof payload !== 'string' &&

--- a/test/index.js
+++ b/test/index.js
@@ -24,6 +24,19 @@ const expect = Code.expect;
 
 describe('inject()', () => {
 
+    it('works when accessing req.socket properties', async () => {
+
+        const dispatch = function (req, res) {
+
+            req.socket.foo;
+            res.end('foo');
+        };
+
+        const res = await Shot.inject(dispatch, '/');
+
+        expect(res.payload).to.equal('foo');
+    });
+
     it('returns non-chunked payload', async () => {
 
         const output = 'example.com:8080|/hello';


### PR DESCRIPTION
I would like to use `shot` to test koa middlewares. Unfortunately this is not possible yet, because koa tries to access `req.socket.encrypted`.
This PR adds `socket` to each instance of `Request` and assigns an empty object to it.