### PR TITLE
work around Node's DEP0066

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -15,7 +15,6 @@ exports = module.exports = internals.Response = class extends Http.ServerRespons
 
         super({ method: req.method, httpVersionMajor: 1, httpVersionMinor: 1 });
         this._shot = { headers: null, trailers: {}, payloadChunks: [] };
-        this._headers = {};      // This forces node@8 to always render the headers
         this.assignSocket(internals.nullSocket());
 
         this.once('finish', () => {
@@ -27,6 +26,27 @@ exports = module.exports = internals.Response = class extends Http.ServerRespons
     }
 
     writeHead(...args) {
+
+        // Find the headers object, if one was provided. If a headers object is
+        // present, call setHeader() on the first valid header, and then break
+        // out of the loop and call writeHead(). By calling setHeader(), Node
+        // will materialize a headers object. This eliminates the need to
+        // access the deprecated _headers object directly.
+        const headers = args[args.length - 1];
+
+        if (typeof headers === 'object' && headers !== null) {
+            const headerNames = Object.keys(headers);
+
+            for (let i = 0; i < headerNames.length; ++i) {
+                const name = headerNames[i];
+
+                try {
+                    this.setHeader(name, headers[name]);
+                    break;
+                }
+                catch (ignoreErr) {} // Let the real writeHead() handle errors.
+            }
+        }
 
         const result = super.writeHead(...args);
 

--- a/test/index.js
+++ b/test/index.js
@@ -503,6 +503,35 @@ describe('writeHead()', () => {
         expect(res.statusMessage).to.equal(statusMessage);
         expect(res.payload).to.equal(reply);
     });
+
+    it('handles a null headers object', async () => {
+
+        const reply = 'Hello World';
+        const statusCode = 200;
+        const statusMessage = 'OK';
+        const dispatch = function (req, res) {
+
+            res.writeHead(statusCode, statusMessage, null);
+            res.end(reply);
+        };
+
+        const res = await Shot.inject(dispatch, { method: 'get', url: '/' });
+        expect(res.statusCode).to.equal(statusCode);
+        expect(res.statusMessage).to.equal(statusMessage);
+        expect(res.payload).to.equal(reply);
+    });
+
+    it('handles falsy header names', async () => {
+
+        const dispatch = function (req, res) {
+
+            res.writeHead(200, 'OK', { '': 'foo' });
+            res.end('Hello World');
+        };
+
+        const promise = Shot.inject(dispatch, { method: 'get', url: '/' });
+        await expect(promise).to.reject(/must be a valid HTTP token/i);
+    });
 });
 
 describe('_read()', () => {


### PR DESCRIPTION
`OutgoingMessage.prototype._headers` is deprecated in Node core, and began showing a deprecation warning in Node 12. This commit updates shot to avoid accessing `_headers`.

Fixes: https://github.com/hapijs/shot/issues/108