### PR TITLE
Use WHATWG URL when possible

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -22,8 +22,16 @@ exports = module.exports = internals.Request = class extends Stream.Readable {
             url = Url.format(url);
         }
 
-        const uri = Url.parse(url);
-        this.url = uri.path;
+        let uri;
+
+        try {
+            uri = new Url.URL(url);
+        }
+        catch (ignoreError) {
+            uri = Url.parse(url);
+        }
+
+        this.url = uri.path || uri;
 
         this.httpVersion = '1.1';
         this.method = (options.method ? options.method.toUpperCase() : 'GET');

--- a/test/index.js
+++ b/test/index.js
@@ -20,14 +20,14 @@ describe('inject()', () => {
 
     it('returns non-chunked payload', async () => {
 
-        const output = 'example.com:8080|/hello';
+        const output = 'http://example.com:8080/hello';
 
         const dispatch = function (req, res) {
 
             res.statusMessage = 'Super';
             res.setHeader('x-extra', 'hello');
             res.writeHead(200, { 'Content-Type': 'text/plain', 'Content-Length': output.length });
-            res.end(req.headers.host + '|' + req.url);
+            res.end(req.url.toString());
         };
 
         const res = await Shot.inject(dispatch, 'http://example.com:8080/hello');
@@ -42,7 +42,7 @@ describe('inject()', () => {
             'content-length': output.length
         });
         expect(res.payload).to.equal(output);
-        expect(res.rawPayload.toString()).to.equal('example.com:8080|/hello');
+        expect(res.rawPayload.toString()).to.equal('http://example.com:8080/hello');
     });
 
     it('returns single buffer payload', async () => {
@@ -50,15 +50,15 @@ describe('inject()', () => {
         const dispatch = function (req, res) {
 
             res.writeHead(200, { 'Content-Type': 'text/plain' });
-            res.end(req.headers.host + '|' + req.url);
+            res.end(req.url.toString());
         };
 
         const res = await Shot.inject(dispatch, { url: 'http://example.com:8080/hello' });
         expect(res.headers.date).to.exist();
         expect(res.headers.connection).to.exist();
         expect(res.headers['transfer-encoding']).to.equal('chunked');
-        expect(res.payload).to.equal('example.com:8080|/hello');
-        expect(res.rawPayload.toString()).to.equal('example.com:8080|/hello');
+        expect(res.payload).to.equal('http://example.com:8080/hello');
+        expect(res.rawPayload.toString()).to.equal('http://example.com:8080/hello');
     });
 
     it('passes headers', async () => {
@@ -169,14 +169,28 @@ describe('inject()', () => {
         expect(res.payload).to.equal('example.com:443');
     });
 
+    it('includes URL hashes', async () => {
+
+        const url = 'http://example.com/hello#hapi';
+
+        const dispatch = function (req, res) {
+
+            res.writeHead(200, { 'Content-Type': 'text/plain' });
+            res.end(req.url.toString());
+        };
+
+        const res = await Shot.inject(dispatch, { url });
+        expect(res.payload).to.equal(url);
+    });
+
     it('optionally accepts an object as url', async () => {
 
-        const output = 'example.com:8080|/hello?test=1234';
+        const output = 'http://example.com:8080/hello?test=1234';
 
         const dispatch = function (req, res) {
 
             res.writeHead(200, { 'Content-Type': 'text/plain', 'Content-Length': output.length });
-            res.end(req.headers.host + '|' + req.url);
+            res.end(req.url.toString());
         };
 
         const url = {


### PR DESCRIPTION
hapi transitioned to the WHATWG URL in v18. Calling `request.url` returns the URL instance. This is not true when injecting requests into a hapi using `server.inject` because shot doesn't use WHATWG URLs yet.

This PR is an attempt to transition to WHATWG URLs in shot instead of purely rely on the deprecated URL API.

The implementation may need further refinements. I'm happy to support code changes.