### PR TITLE
Revert "Fix cleanup to be consistent across node releases"

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -13,10 +13,7 @@ exports = module.exports = internals.Request = class extends Stream.Readable {
 
     constructor(options) {
 
-        super({
-            emitClose: !!(options.simulate && options.simulate.close),
-            autoDestroy: true        // This is the default in node 14+
-        });
+        super();
 
         // options: method, url, payload, headers, remoteAddress
 
@@ -139,10 +136,18 @@ exports = module.exports = internals.Request = class extends Stream.Readable {
                 this.emit('error', new Error('Simulated'));
             }
 
+            if (this._shot.simulate.close) {
+                this.emit('close');
+            }
+
             if (this._shot.simulate.end !== false) {        // 'end' defaults to true
                 this.push(null);
             }
         });
+    }
+
+    destroy() {
+
     }
 };
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -82,6 +82,10 @@ exports = module.exports = internals.Response = class extends Http.ServerRespons
         this.emit('finish');
     }
 
+    destroy() {
+
+    }
+
     addTrailers(trailers) {
 
         for (const key in trailers) {

--- a/test/index.js
+++ b/test/index.js
@@ -562,25 +562,6 @@ describe('_read()', () => {
         expect(res.payload).to.equal(body);
     });
 
-    it('supports async iteration', async () => {
-
-        const dispatch = async function (req, res) {
-
-            let buffer = '';
-            for await (const chunk of req) {
-                buffer = buffer + chunk.toString();
-            }
-
-            res.writeHead(200, { 'Content-Length': 0 });
-            res.end(buffer);
-            req.destroy();
-        };
-
-        const body = 'something special just for you';
-        const res = await Shot.inject(dispatch, { method: 'get', url: '/', payload: body });
-        expect(res.payload).to.equal(body);
-    });
-
     it('simulates split', async () => {
 
         const dispatch = function (req, res) {


### PR DESCRIPTION
This reverts commit 50ceba63ec72d01b3298a6384f1498f578f9dbf6.

This change caused a regression in the hapi test suite.