### PR TITLE
test: add a 'close' simulation when 'end' is false

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -640,7 +640,7 @@ describe('_read()', () => {
         expect(end).to.equal(false);
     });
 
-    it('simulates close', async () => {
+    it('simulates close (end = true)', async () => {
 
         const dispatch = function (req, res) {
 
@@ -661,7 +661,32 @@ describe('_read()', () => {
         };
 
         const body = 'something special just for you';
-        const res = await Shot.inject(dispatch, { method: 'get', url: '/', payload: body, simulate: { close: true } });
+        const res = await Shot.inject(dispatch, { method: 'get', url: '/', payload: body, simulate: { close: true, end: true } });
+        expect(res.payload).to.equal('close');
+    });
+
+    it('simulates close (end = false)', async () => {
+
+        const dispatch = function (req, res) {
+
+            let buffer = '';
+            req.on('readable', () => {
+
+                buffer = buffer + (req.read() || '');
+            });
+
+            req.on('close', () => {
+
+                res.writeHead(200, { 'Content-Length': 0 });
+                res.end('close');
+            });
+
+            req.on('end', () => {
+            });
+        };
+
+        const body = 'something special just for you';
+        const res = await Shot.inject(dispatch, { method: 'get', url: '/', payload: body, simulate: { close: true, end: false } });
         expect(res.payload).to.equal('close');
     });
 


### PR DESCRIPTION
This commit adds a regression test for the situation where the
'close' event is simulated, but the 'end' event is not. This
scenario failed in the hapi test suite, and caused the quick
revert of the shot v5.0.2 release.