### PR TITLE
fix: do not auto destroy request stream

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -145,6 +145,10 @@ exports = module.exports = internals.Request = class extends Stream.Readable {
             }
         });
     }
+
+    destroy() {
+
+    }
 };
 
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -13,7 +13,7 @@ exports = module.exports = internals.Request = class extends Stream.Readable {
 
     constructor(options) {
 
-        super({ autoDestroy: false });
+        super();
 
         // options: method, url, payload, headers, remoteAddress
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -146,7 +146,7 @@ exports = module.exports = internals.Request = class extends Stream.Readable {
         });
     }
 
-    destroy() {
+    _destroy() {
 
     }
 };

--- a/lib/request.js
+++ b/lib/request.js
@@ -13,7 +13,7 @@ exports = module.exports = internals.Request = class extends Stream.Readable {
 
     constructor(options) {
 
-        super();
+        super({ autoDestroy: false });
 
         // options: method, url, payload, headers, remoteAddress
 
@@ -144,10 +144,6 @@ exports = module.exports = internals.Request = class extends Stream.Readable {
                 this.push(null);
             }
         });
-    }
-
-    _destroy() {
-
     }
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -483,6 +483,30 @@ describe('inject()', () => {
         const res = await Shot.inject(dispatch, { method: 'post', url: '/', payload: internals.getTestStream(), headers });
         expect(res.payload).to.equal('100');
     });
+
+    it('iterates over payload', async () => {
+
+        const dispatch = async function (req, res) {
+
+            let output = '';
+
+            for await (const chunk of req) {
+                output += chunk.toString();
+            }
+
+            res.writeHead(200, { 'Content-Length': output.length });
+            res.end(output);
+            req.destroy();
+        };
+
+        const body = Buffer.from('something special just for you');
+        const res = await Shot.inject(dispatch, {
+            method: 'get',
+            url: '/',
+            payload: body
+        });
+        expect(res.payload.toString()).to.equal(body.toString());
+    });
 });
 
 describe('writeHead()', () => {


### PR DESCRIPTION
Auto destroying the request stream stops `for await..of`-style iteration over request payloads working when `output: 'stream', parse: false` are used as request handler payload config options.

Fixes hapijs/hapi#4149