### PR TITLE
Another attempt at #129

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -13,7 +13,10 @@ exports = module.exports = internals.Request = class extends Stream.Readable {
 
     constructor(options) {
 
-        super();
+        super({
+            emitClose: !!(options.simulate && options.simulate.close),
+            autoDestroy: true        // This is the default in node 14+
+        });
 
         // options: method, url, payload, headers, remoteAddress
 
@@ -133,21 +136,15 @@ exports = module.exports = internals.Request = class extends Stream.Readable {
             }
 
             if (this._shot.simulate.error) {
-                this.emit('error', new Error('Simulated'));
+                this.destroy(new Error('Simulated'));
             }
-
-            if (this._shot.simulate.close) {
-                this.emit('close');
-            }
-
-            if (this._shot.simulate.end !== false) {        // 'end' defaults to true
+            else if (this._shot.simulate.end !== false) {        // 'end' defaults to true
                 this.push(null);
             }
+            else if (this._shot.simulate.close) {                // manually close (out of spec)
+                this.emit('close');
+            }
         });
-    }
-
-    destroy() {
-
     }
 };
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -82,10 +82,6 @@ exports = module.exports = internals.Response = class extends Http.ServerRespons
         this.emit('finish');
     }
 
-    destroy() {
-
-    }
-
     addTrailers(trailers) {
 
         for (const key in trailers) {

--- a/test/index.js
+++ b/test/index.js
@@ -573,6 +573,25 @@ describe('_read()', () => {
         expect(events).to.equal(['end']);
     });
 
+    it('supports async iteration', async () => {
+
+        const dispatch = async function (req, res) {
+
+            let buffer = '';
+            for await (const chunk of req) {
+                buffer = buffer + chunk.toString();
+            }
+
+            res.writeHead(200, { 'Content-Length': 0 });
+            res.end(buffer);
+            req.destroy();
+        };
+
+        const body = 'something special just for you';
+        const res = await Shot.inject(dispatch, { method: 'get', url: '/', payload: body });
+        expect(res.payload).to.equal(body);
+    });
+
     it('simulates split', async () => {
 
         const events = [];


### PR DESCRIPTION
This version is mostly identical to the old, except that it will now emit an out-of-spec 'close' event (ie. without a preceding 'end' or 'error' emit), when requested.

Additionally, the `error` emit, is now handled through calling `destroy()`, which is the correct way, and ensures that it respects the `emitClose: true` option.

This should behave identically to the existing implementation, except that it fixes the bug in hapijs/hapi#4149, and another exposed in 13a94e2, where 'close' & 'end' are emitted in the wrong order.