### PR TITLE
emit res close event

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -14,8 +14,25 @@ exports = module.exports = internals.Response = class extends Http.ServerRespons
     constructor(req, onEnd) {
 
         super({ method: req.method, httpVersionMajor: 1, httpVersionMinor: 1 });
-        this._shot = { headers: null, trailers: {}, payloadChunks: [] };
+        this._shot = { headers: null, trailers: {}, payloadChunks: [], closed: false };
         this.assignSocket(internals.nullSocket());
+
+        this.once('close', () => {
+
+            this._shot.closed = true;
+        });
+
+        req.once('close', () => {
+
+            process.nextTick(() => {
+
+                /* $lab:coverage:off$ */
+                if (!this._shot.closed) {
+                /* $lab:coverage:on$ */
+                    this.emit('close');
+                }
+            });
+        });
 
         this.once('finish', () => {
 


### PR DESCRIPTION
This commit updates the response logic to emit the 'close' event if the request is closed.

Refs: https://github.com/hapijs/hapi/issues/4208

I tested these changes in hapi's master branch (combined with the change mentioned [here](https://github.com/hapijs/hapi/issues/4208#issuecomment-755376829)) on Node 15.4.0, 15.5.1 (the currently broken release), 14.15.0, and 12.18.4. 🤷 