### PR TITLE
When simulating close, ensure res emits close.

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -17,6 +17,15 @@ exports = module.exports = internals.Response = class extends Http.ServerRespons
         this._shot = { headers: null, trailers: {}, payloadChunks: [] };
         this.assignSocket(internals.nullSocket());
 
+        if (req._shot.simulate.close) {
+            // Ensure premature, manual close is forwarded to res.
+            // In HttpServer the socket closing actually triggers close on both req and res.
+            req.once('close', () => {
+
+                process.nextTick(() => this.emit('close'));
+            });
+        }
+
         this.once('finish', () => {
 
             const res = internals.payload(this);

--- a/test/index.js
+++ b/test/index.js
@@ -13,11 +13,11 @@ const Code = require('@hapi/code');
 const internals = {};
 
 
-internals.trackStreamLifetime = function (stream, list) {
+internals.trackStreamLifetime = function (stream, list, tag) {
 
     const events = ['close', 'error', 'end', 'finish'];
     for (const event of events) {
-        stream.on(event, () => list.push(event));
+        stream.on(event, () => list.push(tag ? `${event} (${tag})` : event));
     }
 };
 
@@ -680,13 +680,14 @@ describe('_read()', () => {
                 res.end('close');
             });
 
-            internals.trackStreamLifetime(req, events);
+            internals.trackStreamLifetime(req, events, 'req');
+            internals.trackStreamLifetime(res, events, 'res');
         };
 
         const body = 'something special just for you';
         const res = await Shot.inject(dispatch, { method: 'get', url: '/', payload: body, simulate: { error: true, close: true } });
         expect(res.payload).to.equal('close');
-        expect(events).to.equal(['error', 'close']);
+        expect(events).to.equal(['error (req)', 'finish (res)', 'close (req)', 'close (res)']);
     });
 
     it('simulates no end without payload', async () => {
@@ -734,13 +735,14 @@ describe('_read()', () => {
                 res.end('close');
             });
 
-            internals.trackStreamLifetime(req, events);
+            internals.trackStreamLifetime(req, events, 'req');
+            internals.trackStreamLifetime(res, events, 'res');
         };
 
         const body = 'something special just for you';
         const res = await Shot.inject(dispatch, { method: 'get', url: '/', payload: body, simulate: { close: true, end: true } });
         expect(res.payload).to.equal('close');
-        expect(events).to.equal(['end', 'close']);
+        expect(events).to.equal(['end (req)', 'finish (res)', 'close (req)', 'close (res)']);
     });
 
     it('simulates close (end = false)', async () => {
@@ -760,13 +762,14 @@ describe('_read()', () => {
                 res.end('close');
             });
 
-            internals.trackStreamLifetime(req, events);
+            internals.trackStreamLifetime(req, events, 'req');
+            internals.trackStreamLifetime(res, events, 'res');
         };
 
         const body = 'something special just for you';
         const res = await Shot.inject(dispatch, { method: 'get', url: '/', payload: body, simulate: { close: true, end: false } });
         expect(res.payload).to.equal('close');
-        expect(events).to.equal(['close']);
+        expect(events).to.equal(['finish (res)', 'close (req)', 'close (res)']);
     });
 
     it('errors for invalid input options', async () => {


### PR DESCRIPTION
In followup to #138 I've implemented the proposed fix.  By looking at #138 you can see that the changes are nearly identical, but here we only handle the case of simulating a close rather than ensuring that res _always_ emits `'close'` any time req emits `'close'`.

It's worth mentioning I also experimented with a separate approach of using the socket to propagate these events (as is done internally to node).  My hope was that shot would then inherit a nice subset of node behaviors, and in turn be more accurate to a real/live http server.  It was interesting and there were some positive results, but it was more complex and wasn't the right approach to address this particular issue.

Refs: https://github.com/hapijs/hapi/issues/4208

I tested these changes with hapi against node v15.5.1, v14.15.4, and v12.19.1.