### PR TITLE
Add initial typescript support

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,177 @@
+
+import {
+    IncomingHttpHeaders,
+    IncomingMessage,
+    OutgoingHttpHeaders,
+    ServerResponse
+} from 'http';
+import { Readable, Stream } from 'stream';
+import { UrlObject } from 'url';
+
+
+export interface InjectedRequest extends Readonly<Readable> {
+    readonly httpVersion: '1.1';
+    readonly method: string;
+    readonly url: string;
+    readonly headers: Readonly<IncomingHttpHeaders>;
+    readonly connection: {
+        readonly remoteAddress: string;
+    };
+}
+
+export type MaybeInjectedRequest = InjectedRequest | IncomingMessage;
+
+export interface ResponseObject {
+    /**
+     * An object containing the raw request and response objects.
+     */
+    raw: {
+        /**
+         * The simulated request object.
+         */
+        req: InjectedRequest;
+
+        /**
+         * The simulated response object.
+         */
+        res: ServerResponse;
+    };
+
+    /**
+     * An object containing the response headers.
+     */
+    headers: OutgoingHttpHeaders;
+
+    /**
+     * The HTTP status code.
+     */
+    statusCode: number;
+
+    /**
+     * The HTTP status message.
+     */
+    statusMessage: string;
+
+    /**
+     * The payload as a UTF-8 encoded string.
+     */
+    payload: string;
+
+    /**
+     * The raw payload as a Buffer.
+     */
+    rawPayload: Buffer;
+
+    /**
+     * An object containing the response trailers
+     */
+    trailers: NodeJS.Dict<string>;
+}
+
+type PartialURL = Pick<UrlObject, 'protocol' | 'hostname' | 'port' | 'query'> & { pathname: string };
+
+export interface RequestOptions {
+
+    /**
+     * The request URL.
+     */
+    url: string | PartialURL;
+
+    /**
+     * The HTTP request method.
+     * 
+     * @default 'GET'
+     */
+    method?: string;
+
+    /**
+     * The HTTP HOST header value to be used if no header is provided,
+     * and the url does not include an authority component.
+     *
+     * @default 'localhost'
+     */
+    authority?: string;
+
+    /**
+     * The request headers.
+     */
+    headers?: OutgoingHttpHeaders;
+
+    /**
+     * The client remote address.
+     *
+     * @default '127.0.0.1'
+     */
+    remoteAddress?: string;
+
+    /**
+     * A request payload. Can be a string, Buffer, Stream or object that will be stringified.
+     */
+    payload?: string | Buffer | Stream | object;
+
+    /**
+     * an object containing flags to simulate various conditions:
+    */
+    simulate?: {
+
+        /**
+         * indicates whether the request will fire an end event.
+         *
+         * @default true
+         */
+        end?: boolean;
+
+        /**
+         * indicates whether the request payload will be split into chunks.
+         *
+         * @default false
+         */
+        split?: boolean;
+
+        /**
+         * whether the request will emit an error event.
+         * If set to true, the emitted error will have a message of 'Simulated'.
+         *
+         * @default false
+         */
+        error?: boolean;
+
+        /**
+         * whether the request will emit a close event.
+         *
+         * @default true
+         */
+        close?: boolean;
+    };
+
+    /**
+     * Optional flag to validate this options object.
+     *
+     * @default true
+     */
+    validate?: boolean;
+}
+
+type InjectionListener = (req: InjectedRequest, res: ServerResponse) => void;
+
+type MaybeInjectionListener = (req: MaybeInjectedRequest, res: ServerResponse) => void;
+
+/**
+ * Injects a fake request into an HTTP server.
+ *
+ * @param dispatchFunc - Listener function. Similar as you would pass to Http.createServer when making a node HTTP server.
+ * @param options - Request options object or string with request url.
+ *
+ * @return A Promise that resolves with a ResponseObject object
+ */
+export function inject(dispatchFunc: InjectionListener, options: RequestOptions | string): Promise<ResponseObject>;
+export function inject(dispatchFunc: MaybeInjectionListener, options: RequestOptions | string): Promise<ResponseObject>;
+
+/**
+ * Checks if given object is a Shot Request object.
+ *
+ * @param obj - the req or res object to test
+ *
+ * @return true if the object is a shot request, otherwise false.
+ */
+export function isInjection(obj: MaybeInjectedRequest | ServerResponse): boolean;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "5.0.5",
   "repository": "git://github.com/hapijs/shot",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "lib"
   ],
@@ -19,10 +20,11 @@
   },
   "devDependencies": {
     "@hapi/code": "8.x.x",
-    "@hapi/lab": "24.x.x"
+    "@hapi/lab": "24.x.x",
+    "typescript": "~4.0.7"
   },
   "scripts": {
-    "test": "lab -a @hapi/code -t 100 -L",
+    "test": "lab -a @hapi/code -t 100 -L -Y",
     "test-cov-html": "lab -a @hapi/code -r html -o coverage.html -L"
   },
   "license": "BSD-3-Clause"

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,63 @@
+import { IncomingMessage, ServerResponse } from 'http';
+import { Readable } from 'stream';
+
+import * as Lab from '@hapi/lab';
+import * as Shot from '..';
+
+
+const { expect } = Lab.types;
+
+
+const dispatch = function (req: Shot.MaybeInjectedRequest, res: ServerResponse) {
+
+    res.end();
+};
+
+const plain = function (req: IncomingMessage, res: ServerResponse) {
+
+    res.end();
+};
+
+// Shot.inject()
+
+expect.type<Shot.ResponseObject>(await Shot.inject(dispatch, '/'));
+expect.type<Shot.ResponseObject>(await Shot.inject(dispatch, { url: '/'}));
+expect.type<Shot.ResponseObject>(await Shot.inject(dispatch, { url: { pathname: '/', query: { a: 'b' } } }));
+expect.type<Shot.ResponseObject>(await Shot.inject(dispatch, { url: '/', payload: 'string' }));
+expect.type<Shot.ResponseObject>(await Shot.inject(dispatch, { url: '/', payload: Buffer.from('buffer') }));
+expect.type<Shot.ResponseObject>(await Shot.inject(dispatch, { url: '/', payload: { ja: 'son' } }));
+expect.type<Shot.ResponseObject>(await Shot.inject(dispatch, { url: '/', payload: new Readable({ read() { this.push(null); } }) }));
+expect.type<Shot.ResponseObject>(await Shot.inject(dispatch, {
+    url: '/',
+    method: 'POST',
+    authority: 'server',
+    headers: { a: 'b', c: ['d'], e: 1 },
+    remoteAddress: '1.2.3.4',
+    payload: 'value',
+    simulate: {
+        end: false,
+        split: true,
+        error: true,
+        close: false
+    },
+    validate: false
+}));
+
+expect.error(await Shot.inject());
+expect.error(await Shot.inject(dispatch));
+expect.error(await Shot.inject(dispatch, {}));
+expect.error(await Shot.inject(dispatch, { url: {} }));
+expect.error(await Shot.inject(plain, '/'));
+
+// Shot.isInjection()
+
+await Shot.inject((req: Shot.MaybeInjectedRequest, res) => {
+
+    expect.type<boolean>(Shot.isInjection(req));
+    expect.type<boolean>(Shot.isInjection(res));
+
+    res.end();
+}, '/');
+
+expect.error(Shot.isInjection({}))
+expect.error(Shot.isInjection())


### PR DESCRIPTION
I have taken care to name type exports for compatibility with the current usage in [`@types/hapi__hapi`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/hapi__hapi/index.d.ts).