### PR TITLE
Drop node v12 support

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -3,6 +3,7 @@ name: ci
 on:
   push:
     branches:
+      - v6
       - master
   pull_request:
   workflow_dispatch:
@@ -10,3 +11,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/lib/request.js
+++ b/lib/request.js
@@ -14,7 +14,7 @@ exports = module.exports = internals.Request = class extends Stream.Readable {
     constructor(options) {
 
         super({
-            emitClose: !!(options.simulate && options.simulate.close),
+            emitClose: !!(options.simulate?.close),
             autoDestroy: true        // This is the default in node 14+
         });
 
@@ -32,14 +32,14 @@ exports = module.exports = internals.Request = class extends Stream.Readable {
         this.method = (options.method ? options.method.toUpperCase() : 'GET');
 
         this.headers = {};
-        const headers = options.headers || {};
+        const headers = options.headers ?? {};
         const fields = Object.keys(headers);
         fields.forEach((field) => {
 
             this.headers[field.toLowerCase()] = headers[field];
         });
 
-        this.headers['user-agent'] = this.headers['user-agent'] || 'shot';
+        this.headers['user-agent'] = this.headers['user-agent'] ?? 'shot';
 
         const hostHeaderFromUri = function () {
 
@@ -54,13 +54,14 @@ exports = module.exports = internals.Request = class extends Stream.Readable {
             return null;
         };
 
-        this.headers.host = this.headers.host || hostHeaderFromUri() || options.authority || 'localhost:80';
+        this.headers.host = this.headers.host ?? hostHeaderFromUri() ?? options.authority ?? 'localhost:80';
 
-        this.connection = {
-            remoteAddress: options.remoteAddress || '127.0.0.1'
+        // NOTE connection is deprecated in favor of socket as of node v13
+        this.socket = this.connection = {
+            remoteAddress: options.remoteAddress ?? '127.0.0.1'
         };
 
-        let payload = options.payload || null;
+        let payload = options.payload ?? null;
         if (payload &&
             typeof payload !== 'string' &&
             !(payload instanceof Stream) &&
@@ -84,7 +85,7 @@ exports = module.exports = internals.Request = class extends Stream.Readable {
         this._shot = {
             payload,
             isDone: false,
-            simulate: options.simulate || {}
+            simulate: options.simulate ?? {}
         };
 
         return this;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hapi/shot",
   "description": "Injects a fake HTTP request/response into a node HTTP server",
-  "version": "5.0.5",
+  "version": "6.0.0-beta.0",
   "repository": "git://github.com/hapijs/shot",
   "main": "lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@hapi/code": "8.x.x",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x"
+    "@hapi/lab": "25.0.0-beta.0"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@hapi/validate": "1.x.x"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "9.0.0-beta.0",
     "@hapi/eslint-plugin": "*",
     "@hapi/lab": "25.0.0-beta.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -87,8 +87,10 @@ describe('inject()', () => {
 
         const dispatch = function (req, res) {
 
+            expect(req.socket).to.shallow.equal(req.connection);
+
             res.writeHead(200, { 'Content-Type': 'text/plain' });
-            res.end(req.connection.remoteAddress);
+            res.end(req.socket.remoteAddress);
         };
 
         const res = await Shot.inject(dispatch, { method: 'get', url: 'http://example.com:8080/hello', remoteAddress: '1.2.3.4' });
@@ -99,8 +101,10 @@ describe('inject()', () => {
 
         const dispatch = function (req, res) {
 
+            expect(req.socket).to.shallow.equal(req.connection);
+
             res.writeHead(200, { 'Content-Type': 'text/plain' });
-            res.end(req.connection.remoteAddress);
+            res.end(req.socket.remoteAddress);
         };
 
         const res = await Shot.inject(dispatch, { method: 'get', url: 'http://example.com:8080/hello' });


### PR DESCRIPTION
Dropping node v12 support.  Also supporting the `req.socket` property which replaces the `req.connection` property deprecated as of node v13.