### PR TITLE
More realistic request socket interface

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -3,6 +3,7 @@ name: ci
 on:
   push:
     branches:
+      - v6
       - master
   pull_request:
   workflow_dispatch:
@@ -10,3 +11,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/lib/request.js
+++ b/lib/request.js
@@ -14,7 +14,7 @@ exports = module.exports = internals.Request = class extends Stream.Readable {
     constructor(options) {
 
         super({
-            emitClose: !!(options.simulate && options.simulate.close),
+            emitClose: !!(options.simulate?.close),
             autoDestroy: true        // This is the default in node 14+
         });
 
@@ -32,14 +32,14 @@ exports = module.exports = internals.Request = class extends Stream.Readable {
         this.method = (options.method ? options.method.toUpperCase() : 'GET');
 
         this.headers = {};
-        const headers = options.headers || {};
+        const headers = options.headers ?? {};
         const fields = Object.keys(headers);
         fields.forEach((field) => {
 
             this.headers[field.toLowerCase()] = headers[field];
         });
 
-        this.headers['user-agent'] = this.headers['user-agent'] || 'shot';
+        this.headers['user-agent'] = this.headers['user-agent'] ?? 'shot';
 
         const hostHeaderFromUri = function () {
 
@@ -54,13 +54,14 @@ exports = module.exports = internals.Request = class extends Stream.Readable {
             return null;
         };
 
-        this.headers.host = this.headers.host || hostHeaderFromUri() || options.authority || 'localhost:80';
+        this.headers.host = this.headers.host ?? hostHeaderFromUri() ?? options.authority ?? 'localhost:80';
 
-        this.connection = {
-            remoteAddress: options.remoteAddress || '127.0.0.1'
+        // NOTE connection is deprecated in favor of socket as of node v13
+        this.socket = this.connection = {
+            remoteAddress: options.remoteAddress ?? '127.0.0.1'
         };
 
-        let payload = options.payload || null;
+        let payload = options.payload ?? null;
         if (payload &&
             typeof payload !== 'string' &&
             !(payload instanceof Stream) &&
@@ -84,7 +85,7 @@ exports = module.exports = internals.Request = class extends Stream.Readable {
         this._shot = {
             payload,
             isDone: false,
-            simulate: options.simulate || {}
+            simulate: options.simulate ?? {}
         };
 
         return this;

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Events = require('events');
 const Stream = require('stream');
 const Url = require('url');
 
@@ -57,9 +58,7 @@ exports = module.exports = internals.Request = class extends Stream.Readable {
         this.headers.host = this.headers.host ?? hostHeaderFromUri() ?? options.authority ?? 'localhost:80';
 
         // NOTE connection is deprecated in favor of socket as of node v13
-        this.socket = this.connection = {
-            remoteAddress: options.remoteAddress ?? '127.0.0.1'
-        };
+        this.socket = this.connection = new internals.MockSocket(options);
 
         let payload = options.payload ?? null;
         if (payload &&
@@ -151,3 +150,18 @@ exports = module.exports = internals.Request = class extends Stream.Readable {
 
 
 internals.Request.prototype[Symbols.injection] = true;
+
+internals.MockSocket = class MockSocket extends Events.EventEmitter {
+
+    constructor({ remoteAddress }) {
+
+        super();
+
+        this.remoteAddress = remoteAddress ?? '127.0.0.1';
+    }
+
+    // Net.Socket APIs used by hapi
+
+    end() {}
+    setTimeout() {}
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hapi/shot",
   "description": "Injects a fake HTTP request/response into a node HTTP server",
-  "version": "5.0.5",
+  "version": "6.0.0-beta.0",
   "repository": "git://github.com/hapijs/shot",
   "main": "lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@hapi/code": "8.x.x",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x"
+    "@hapi/lab": "25.0.0-beta.0"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hapi/shot",
   "description": "Injects a fake HTTP request/response into a node HTTP server",
-  "version": "6.0.0-beta.0",
+  "version": "6.0.0-beta.1",
   "repository": "git://github.com/hapijs/shot",
   "main": "lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
     ]
   },
   "dependencies": {
-    "@hapi/hoek": "9.x.x",
-    "@hapi/validate": "1.x.x"
+    "@hapi/hoek": "^10.0.0",
+    "@hapi/validate": "^2.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "9.0.0-beta.0",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "25.0.0-beta.0"
+    "@hapi/lab": "^25.0.1"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@hapi/validate": "1.x.x"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "9.0.0-beta.0",
     "@hapi/eslint-plugin": "*",
     "@hapi/lab": "25.0.0-beta.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -97,6 +97,22 @@ describe('inject()', () => {
         expect(res.payload).to.equal('1.2.3.4');
     });
 
+    it('recreates request socket interface', async () => {
+
+        const dispatch = function (req, res) {
+
+            expect(req.socket.on).to.be.a.function();
+            expect(req.socket.once).to.be.a.function();
+            expect(req.socket.end).to.be.a.function();
+            expect(req.socket.setTimeout).to.be.a.function();
+
+            res.writeHead(200, { 'Content-Type': 'text/plain' });
+            res.end();
+        };
+
+        await Shot.inject(dispatch, { method: 'get', url: 'http://example.com:8080/hello' });
+    });
+
     it('passes localhost as default remote address', async () => {
 
         const dispatch = function (req, res) {

--- a/test/index.js
+++ b/test/index.js
@@ -87,8 +87,10 @@ describe('inject()', () => {
 
         const dispatch = function (req, res) {
 
+            expect(req.socket).to.shallow.equal(req.connection);
+
             res.writeHead(200, { 'Content-Type': 'text/plain' });
-            res.end(req.connection.remoteAddress);
+            res.end(req.socket.remoteAddress);
         };
 
         const res = await Shot.inject(dispatch, { method: 'get', url: 'http://example.com:8080/hello', remoteAddress: '1.2.3.4' });
@@ -99,8 +101,10 @@ describe('inject()', () => {
 
         const dispatch = function (req, res) {
 
+            expect(req.socket).to.shallow.equal(req.connection);
+
             res.writeHead(200, { 'Content-Type': 'text/plain' });
-            res.end(req.connection.remoteAddress);
+            res.end(req.socket.remoteAddress);
         };
 
         const res = await Shot.inject(dispatch, { method: 'get', url: 'http://example.com:8080/hello' });


### PR DESCRIPTION
After doing some testing with hapi, I found that hapi has certain behaviors when `req.socket` is present versus when it isn't.  With the change in #144 it becomes present for all shot requests.  In turn, hapi requires a more realistic mock request socket since it actually exercises some of its interface.  I have implemented a minimal mock socket for shot, which turns out to be a similar direction that light-my-request took as well.