### PR TITLE
Fix typings of Shot.inject

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -156,9 +156,7 @@ export interface RequestOptions {
     validate?: boolean;
 }
 
-type InjectionListener = (req: InjectedRequest, res: ServerResponse) => void;
-
-type MaybeInjectionListener = (req: MaybeInjectedRequest, res: ServerResponse) => void;
+export type InjectionListener = (req: MaybeInjectedRequest, res: ServerResponse) => void;
 
 /**
  * Injects a fake request into an HTTP server.
@@ -169,7 +167,6 @@ type MaybeInjectionListener = (req: MaybeInjectedRequest, res: ServerResponse) =
  * @return A Promise that resolves with a ResponseObject object
  */
 export function inject(dispatchFunc: InjectionListener, options: RequestOptions | string): Promise<ResponseObject>;
-export function inject(dispatchFunc: MaybeInjectionListener, options: RequestOptions | string): Promise<ResponseObject>;
 
 /**
  * Checks if given object is a Shot Request object.


### PR DESCRIPTION
Without these typescript 4.9 complains when used with `(req, res) => {}` expression and not being able to find the correct type.