### PR TITLE
Support handlers calling res.destroy() to abort sending a response

### DIFF
--- a/API.md
+++ b/API.md
@@ -65,11 +65,12 @@ Returns a response object where:
   - `req` - the simulated request object.
   - `res` - the simulated response object.
 - `headers` - an object containing the response headers.
-- `statusCode` - the HTTP status code.
+- `statusCode` - the HTTP status code. If response is aborted before headers are sent, the code is `499`.
 - `statusMessage` - the HTTP status message.
 - `payload` - the payload as a UTF-8 encoded string.
 - `rawPayload` - the raw payload as a Buffer.
 - `trailers` - an object containing the response trailers.
+- `aborted` - optional property which is `true` for aborted, ie. not fully transmitted, responses.
 
 ### `Shot.isInjection(obj)`
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -47,7 +47,7 @@ export interface ResponseObject {
     headers: OutgoingHttpHeaders;
 
     /**
-     * The HTTP status code.
+     * The HTTP status code. If response is aborted before headers are sent, the code is `499`.
      */
     statusCode: number;
 
@@ -70,6 +70,11 @@ export interface ResponseObject {
      * An object containing the response trailers
      */
     trailers: NodeJS.Dict<string>;
+
+    /**
+     * A boolean which is `true` for aborted, ie. not fully transmitted, responses.
+     */
+    aborted?: true;
 }
 
 type PartialURL = Pick<UrlObject, 'protocol' | 'hostname' | 'port' | 'query'> & { pathname: string };

--- a/lib/response.js
+++ b/lib/response.js
@@ -3,6 +3,8 @@
 const Http = require('http');
 const Stream = require('stream');
 
+const Hoek = require('@hapi/hoek');
+
 const Symbols = require('./symbols');
 
 
@@ -17,21 +19,40 @@ exports = module.exports = internals.Response = class extends Http.ServerRespons
         this._shot = { headers: null, trailers: {}, payloadChunks: [] };
         this.assignSocket(internals.nullSocket());
 
+        this.socket.on('error', Hoek.ignore);        // The socket can be destroyed with an error
+
         if (req._shot.simulate.close) {
             // Ensure premature, manual close is forwarded to res.
             // In HttpServer the socket closing actually triggers close on both req and res.
             req.once('close', () => {
 
-                process.nextTick(() => this.emit('close'));
+                process.nextTick(() => this.destroy());
             });
         }
 
-        this.once('finish', () => {
+        const finalize = (aborted) => {
 
             const res = internals.payload(this);
             res.raw.req = req;
+            if (aborted) {
+                res.aborted = aborted;
+                if (!this.headersSent) {
+                    res.statusCode = 499;
+                }
+            }
+
+            this.removeListener('close', abort);
+
             process.nextTick(() => onEnd(res));
-        });
+        };
+
+        const abort = () => finalize(true);
+
+        this.once('finish', finalize);
+
+        // Add fallback listener that will not be called if 'finish' is emitted first
+
+        this.on('close', abort);
     }
 
     writeHead(...args) {

--- a/test/index.js
+++ b/test/index.js
@@ -586,7 +586,6 @@ describe('inject()', () => {
         const res = await Shot.inject(dispatch, { method: 'get', url: '/' });
         expect(res.aborted).to.be.true();
         expect(res.statusCode).to.equal(499);
-        expect(res.raw.res.errored).to.not.exist();
     });
 
     it('returns aborted on immediate res.destroy(error)', async () => {
@@ -599,7 +598,6 @@ describe('inject()', () => {
         const res = await Shot.inject(dispatch, { method: 'get', url: '/' });
         expect(res.aborted).to.be.true();
         expect(res.statusCode).to.equal(499);
-        expect(res.raw.res.errored).to.be.an.error('stop');
     });
 
     it('returns aborted on res.destroy() while transmitting payload', async () => {
@@ -614,7 +612,6 @@ describe('inject()', () => {
         const res = await Shot.inject(dispatch, { method: 'get', url: '/' });
         expect(res.aborted).to.be.true();
         expect(res.statusCode).to.equal(404);
-        expect(res.raw.res.errored).to.not.exist();
         expect(res.payload).to.equal('data');
     });
 
@@ -630,7 +627,6 @@ describe('inject()', () => {
         const res = await Shot.inject(dispatch, { method: 'get', url: '/' });
         expect(res.aborted).to.be.true();
         expect(res.statusCode).to.equal(404);
-        expect(res.raw.res.errored).to.be.an.error('stop');
         expect(res.payload).to.equal('data');
     });
 
@@ -646,7 +642,6 @@ describe('inject()', () => {
         const res = await Shot.inject(dispatch, { method: 'get', url: '/' });
         expect(res.aborted).to.not.exist();
         expect(res.statusCode).to.equal(404);
-        expect(res.raw.res.errored).to.not.exist();
         expect(res.payload).to.equal('data');
     });
 
@@ -662,7 +657,6 @@ describe('inject()', () => {
         const res = await Shot.inject(dispatch, { method: 'get', url: '/' });
         expect(res.aborted).to.not.exist();
         expect(res.statusCode).to.equal(404);
-        expect(res.raw.res.errored).to.be.an.error('stop');
         expect(res.payload).to.equal('data');
     });
 });


### PR DESCRIPTION
When calling `res.destroy([err])` before `'finish'`, shot will currently either do nothing and never return, or reject/throw an unhandled exception.

This does not seem desirable. This is fixed in this PR by detecting aborted responses, and exposing such through a new `aborted` property. Depending on when the abort happens, more or less of the `response` can be filled in along with it.

I don't think this is a breaking change, since it only changes the behaviour of previously failing `inject()` calls. It can however affect code that relies on the buggy behaviour. One example is [this test from hapi](https://github.com/hapijs/hapi/blob/c42fb6ea1f4666b1ea7ebf12bf02adebc951d7f6/test/payload.js#L64-L80), where inject will now return a value. But the test still passes. In fact all hapi tests still pass.

Note that I'm not really a fan of the new `aborted` property, since you will need to remember to check for it, as the response might otherwise look complete. Ideally this property would only be exposed with an option, and normally just reject with an error. This is however more of a breaking change, and conflicts with how hapi uses this module.